### PR TITLE
Fix compatibility with pandas 3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,6 @@ dependencies:
   - pytest-mock
   - pytest-mypy
   - sphinx
-  - types-pytz
   - pip:
       - build
       - pytest-isort

--- a/src/blp/blp.py
+++ b/src/blp/blp.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Seq
 
 import blpapi
 import pandas
-import pytz
 
 BBG_MONTH_MAP = dict(zip("FGHJKMNQUVXZ", range(1, 13)))
 MONTH_BBG_MAP = {v: k for k, v in BBG_MONTH_MAP.items()}
@@ -353,7 +352,8 @@ class EventHandler:
 def datetime_converter(value: Union[str, datetime.date, datetime.datetime]) -> pandas.Timestamp:
     ts = pandas.Timestamp(value)
     if ts.tz:
-        ts = ts.tz_convert(pytz.FixedOffset(ts.tz.getOffsetInMinutes()))
+        offset = datetime.timedelta(minutes=ts.tz.getOffsetInMinutes())
+        ts = ts.tz_convert(datetime.timezone(offset))
     return ts
 
 

--- a/src/blp/test/test_blp.py
+++ b/src/blp/test/test_blp.py
@@ -2,12 +2,12 @@ import copy
 import datetime
 import itertools
 import queue
+import zoneinfo
 
 import blpapi
 import numpy
 import pandas
 import pytest
-import pytz
 from pandas import Timestamp as TS
 from pandas.testing import assert_frame_equal, assert_series_equal
 
@@ -131,7 +131,7 @@ def bcon(request):
 
 def is_not_market_hours(now=None):
     if not now:
-        now = datetime.datetime.now(tz=pytz.timezone("America/New_York"))
+        now = datetime.datetime.now(tz=zoneinfo.ZoneInfo("America/New_York"))
 
     friday, sunday = (4, 6)
     day_seconds = 24 * 60 * 60


### PR DESCRIPTION
Pandas 3 doesn't use pytz anymore, so it doesn't have a dependency on pytz. blp uses pytz without declaring a dependency on it, so now it fails on import. We could just add the dependency, but pytz itself is deprecated and the use of it is very minimal. In the library we can just use datetime.timezone (available since python 3.2) and in the test we can use zoneinfo (added in python 3.9; python 3.8 hit its end-of-life in 2024).